### PR TITLE
Fix space issue

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 INSTALL_FOLDER=/usr/local/lib/brightnessctl
-BIN_FOLDER=/usr/local/bin # works on most distros, nix needs sthng else
+BIN_FOLDER=/usr/local/bin# works on most distros, nix needs sthng else
 install:
 	echo installing
 	mkdir -p $(INSTALL_FOLDER)


### PR DESCRIPTION
On ubuntu, when tried make install, it stopped because of space for bin folder:

echo installing
installing
mkdir -p /usr/local/lib/brightnessctl
cp -R ./*  /usr/local/lib/brightnessctl/
ln -s /usr/local/lib/brightnessctl/writebrightness.sh /usr/local/bin /brightness
ln: target '/brightness' is not a directory
makefile:4: recipe for target 'install' failed
make: *** [install] Error 1