### PR TITLE
Use min/max values when setting

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -3,4 +3,5 @@
 brightFolder="/sys/class/backlight/intel_backlight/"
 currentBright=`cat $brightFolder"brightness"`
 maxBright=`cat $brightFolder"max_brightness"`
+minBright=$((maxBright / 20))
 stepSize=$((maxBright / 10))

--- a/writebrightness.sh
+++ b/writebrightness.sh
@@ -6,7 +6,15 @@ if [ -z "$1" ]
 then
 	value=$maxBright
 else
-	value=$1
+  if [ $1 -gt $maxBright ]
+  then
+    value=$maxBright
+  elif [ $1 -lt $minBright ]
+  then
+    value=$minBright
+  else
+	  value=$1
+  fi
 fi
 echo "changing brightness to:"
 echo $value | sudo tee $brightFolder"brightness"


### PR DESCRIPTION
To prevent error messages like
```bash
$ brightness+
changing brightness to:
132000
tee: /sys/class/backlight/intel_backlight/brightness: Invalid argument
```
(btw: my allowed maximum brightness in this case is 120000)